### PR TITLE
Remove unused dirtyChai import

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,10 +17,8 @@ npm install --save check-chai
 
 ```js
 var chai = require('chai');
-var dirtyChai = require('dirty-chai');
 var checkChai = require('check-chai');
 var expect = chai.expect;
-chai.use(dirtyChai);
 chai.use(checkChai);
 
 describe('test', function() {


### PR DESCRIPTION
dirtyChai was being imported in the example but never used.

If dirtyChai is actually necessary for using checkChai, ignore this PR and add a code comment to the example to explain that.